### PR TITLE
[ADDITION] Add link to the docs on github page

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,4 +1,5 @@
 # Funkin' Code CookBook
+## [**READ THE DOCUMENTATION HERE**](https://thekade.net/funkin-cookbook/)
 
 Forked from [Haxe Code CookBook](https://github.com/HaxeFoundation/code-cookbook), this is a one stop shop for all Funkin' Modding Tutorials!
 


### PR DESCRIPTION
# What did this PR add?
* This PR adds a link to the docs in case a user stumbles upon this repo, but won't be able to access the link cuz there is none

<img width="715" height="177" alt="image" src="https://github.com/user-attachments/assets/33192337-0f92-4d36-a69c-4499b3269cd2" />
