### PR TITLE
[FIX] Fix `Script Event Callbacks` formatting

### DIFF
--- a/assets/content/cookbook/Advanced/8.ScriptEventCallbacks.md
+++ b/assets/content/cookbook/Advanced/8.ScriptEventCallbacks.md
@@ -11,74 +11,109 @@ Several base classes use functions that get an event dispatched to them whenever
 There is a predefined list of every script event callback the game has set up to be overridable, with their respective event type whose fields you can read from or write to. More of these will be added to the future.
 
 - `onScriptEvent(event:ScriptEvent)` - Called when any sort of script event would get dispatched. This is called before the event's respective callback.
+
     - Available to Songs, Stage Props, Boppers, Characters, Stages, Backing Cards, Note Kinds, Dialogue Boxes, Speakers, Conversations and Modules.
 - `onCreate(event:ScriptEvent)` - Called when the base class gets created in the game.
+
     - Available to Songs, Stage Props, Boppers, Characters, Stages, Backing Cards, Note Kinds, Dialogue Boxes, Speakers, Conversations and Modules.
 - `onDestroy(event:ScriptEvent)` - Called when the base class gets destroyed in the game.
+
     - Available to Songs, Stage Props, Boppers, Characters, Stages, Backing Cards, Note Kinds, Dialogue Boxes, Speakers, Conversations and Modules.
 - `onUpdate(event:UpdateScriptEvent)` - Called when the base class gets updated in the game.
+
     - Available to Songs, Stage Props, Boppers, Characters, Stages, Backing Cards, Note Kinds, Dialogue Boxes, Speakers, Conversations and Modules.
 - `onStateChangeBegin(event:StateChangeScriptEvent)` - Called when the State changing process begins.
+
     - Available to Backing Cards and Modules.
 - `onStateChangeEnd(event:StateChangeScriptEvent)` - Called when the State changing process ends.
+
     - Available to Backing Cards and Modules.
 - `onSubStateOpenBegin(event:SubStateScriptEvent)` - Called when the SubState opening process begins.
+
     - Available to Backing Cards and Modules.
 - `onSubStateOpenEnd(event:SubStateScriptEvent)` - Called when the SubState opening process ends.
+
     - Available to Backing Cards and Modules.
 - `onSubStateCloseBegin(event:SubStateScriptEvent)` - Called when the SubState closing process begins.
+
     - Available to Backing Cards and Modules.
 - `onSubStateCloseEnd(event:SubStateScriptEvent)` - Called when the SubState closing process ends.
+
     - Available to Backing Cards and Modules.
 - `onFocusLost(event:FocusScriptEvent)` - Called when the focus from the game window is lost.
+
     - Available to Backing Cards and Modules.
 - `onFocusGained(event:FocusScriptEvent)` - Called when the focus from the game window is gained.
+
     - Available to Backing Cards and Modules.
 - `onAdd(event:ScriptEvent)` - Called when the base class is added to the game stage.
+
     - Available to Stage Props, Boppers and Characters.
 - `onNoteIncoming(event:NoteScriptEvent)` - Called when a note is within the field of view.
+
     - Available to Songs, Boppers, Characters, Stages, Notekinds and Modules.
 - `onNoteHit(event:HitNoteScriptEvent)` - Called when a note is hit by either character.
+
     - Available to Songs, Boppers, Characters, Stages, Notekinds and Modules.
 - `onNoteMiss(event:NoteScriptEvent)` - Called when a note is missed by either character. 
+
     - Available to Songs, Boppers, Characters, Stages, Notekinds and Modules.
 - `onNoteHoldDrop(event:HoldNoteScriptEvent)` - Called when a hold note is dropped by either character.
+
     - Available to Songs, Boppers, Characters, Stages, Notekinds and Modules.
 - `onStepHit(event:SongTimeScriptEvent)` - Called when the Conductor reaches a new step of the music.
+
     - Available to Songs, Boppers, Characters, Stages, Backing Cards and Modules. 
 - `onBeatHit(event:SongTimeScriptEvent)` - Called when the Conductor reaches a new beat of the music. 
+
     - Available to Songs, Boppers, Characters, Stages, Backing Cards and Modules. 
 - `onPause(event:PauseScriptEvent)` - Called when the main gameplay is paused.
+
     - Available to Songs, Boppers, Characters, Stages and Modules. 
 - `onResume(event:ScriptEvent)` - Called when the main gameplay is resumed.
+
     - Available to Songs, Boppers, Characters, Stages and Modules. 
 - `onSongLoaded(event:SongLoadScriptEvent)` - Called when song chart has been parsed but before the notes have been placed, both when starting the song for the first time and retrying the song.
+
     - Available to Songs, Boppers, Characters, Stages and Modules.
 - `onSongStart(event:ScriptEvent)` - Called when the song starts.
-    - Available to Songs, Boppers, Characters, Stages and Modules. 
+
+    - Available to Songs, Boppers, Characters, Stages and Modules.
 - `onSongEnd(event:ScriptEvent)` - Called when the song ends.
-    - Available to Songs, Boppers, Characters, Stages and Modules. 
+
+    - Available to Songs, Boppers, Characters, Stages and Modules.
 - `onGameOver(event:ScriptEvent)` - Called when the player runs out of health but before the game over substate is opened.
+
     - Available to Songs, Boppers, Characters, Stages and Modules.
 - `onSongRetry(event:SongRetryEvent)` - Called when the song retrying process begins, either through the pause menu or through the game over screen.
+
     - Available to Songs, Boppers, Characters, Stages and Modules.
 - `onNoteGhostMiss(event:GhostMissNoteScriptEvent)` - Called when the player pressed a key with no notes on the strumline.
+
     - Available to Songs, Boppers, Characters, Stages and Modules.
 - `onSongEvent(event:SongEventScriptEvent)` - Called when a song event (such as Focus Camera) is triggered.
+
     - Available to Songs, Boppers, Characters, Stages and Modules.
 - `onCountdownStart(event:CountdownScriptEvent)` - Called when the countdown is about to start.
+
     - Available to Songs, Boppers, Characters, Stages and Modules.
 - `onCountdownStep(event:CountdownScriptEvent)` - Called when a countdown changes its current step.
+
     - Available to Songs, Boppers, Characters, Stages and Modules.
-- `onCountdownEnd(event:CountdownScriptEvent)` - Called when the countdown ends. 
+- `onCountdownEnd(event:CountdownScriptEvent)` - Called when the countdown ends.
+
     - Available to Songs, Boppers, Characters, Stages and Modules.
 - `onDialogueCompleteLine(event:DialogueScriptEvent)` - Called when the player advanced the dialogue while it's being typed.
+
     - Available to Dialogue Boxes, Speakers and Conversations.
 - `onDialogueLine(event:DialogueScriptEvent)` - Called when the player advances the dialogue while it's idling.
+
     - Available to Dialogue Boxes, Speakers and Conversations.
 - `onDialogueSkip(event:DialogueScriptEvent)` - Called when the dialogue gets skipped.
+
     - Available to Dialogue Boxes, Speakers and Conversations.
 - `onDialogueEnd(event:DialogueScriptEvent)` - Called when the dialogue ends.
+
     - Available to Dialogue Boxes, Speakers and Conversations.
 
 ## List of Event Types
@@ -86,96 +121,113 @@ There is a predefined list of every script event callback the game has set up to
 There is a predefined list of script events, whose fields are readable and, in some cases, changeable, that get dispatched to script event callbacks. More of these will be added in the future. See above which callback accepts which event.
 
 - `ScriptEvent`, with fields:
-  - (read-only) `cancelable` - If the event can be canceled.
-  - (read-only) `type` - The type of the event. 
-  - (read-only) `shouldPropagate` - If the event can be dispatched to its respective callback. If false, it will only get dispatched to `onScriptEvent`.
-  - (read-only) `eventCanceled` - If the event has been cancelled.
-  - `cancelEvent()` - Cancels the event, if possible.
-  - `cancel()` - Cancels the event, if possible.
-  - `stopPropagation()` - Stops the propagation of this event.
+
+
+    - (read-only) `cancelable` - If the event can be canceled.
+    - (read-only) `type` - The type of the event.
+    - (read-only) `shouldPropagate` - If the event can be dispatched to its respective callback. If false, it will only get dispatched to `onScriptEvent`.
+    - (read-only) `eventCanceled` - If the event has been cancelled.
+    - `cancelEvent()` - Cancels the event, if possible.
+    - `cancel()` - Cancels the event, if possible.
+    - `stopPropagation()` - Stops the propagation of this event.
 
 - `UpdateScriptEvent`, with fields:
-  - Inherited from `ScriptEvent`.
-  - (read-only) `elapsed` - How much time has passed since the last update.
+
+    - Inherited from `ScriptEvent`.
+    - (read-only) `elapsed` - How much time has passed since the last update.
 
 - `StateChangeScriptEvent`, with fields:
-  - Inherited from `ScriptEvent`.
-  - (read-only) `targetState` - The State that was switched to.
+
+    - Inherited from `ScriptEvent`.
+    - (read-only) `targetState` - The State that was switched to.
 
 - `SubStateScriptEvent`, with fields:
-  - Inherited from `ScriptEvent`.
-  - (read-only) `targetState` - The SubState that was opened/closed.
+
+    - Inherited from `ScriptEvent`.
+    - (read-only) `targetState` - The SubState that was opened/closed.
 
 - `FocusScriptEvent`, with fields:
-  - Inherited from `ScriptEvent`.
+
+    - Inherited from `ScriptEvent`.
 
 - `NoteScriptEvent`, with fields:
-  - Inherited from `ScriptEvent.`
-  - (read-only) `note` - The NoteSprite associated with this event.
-  - (read-only) `comboCount` - The currently ongoing combo.
-  - `playSound` - Whether to play a miss sound when missing a note.
-  - `healthChange` - The amount of health to add to the player. Can be a negative value too.
+
+    - Inherited from `ScriptEvent.`
+    - (read-only) `note` - The NoteSprite associated with this event.
+    - (read-only) `comboCount` - The currently ongoing combo.
+    - `playSound` - Whether to play a miss sound when missing a note.
+    - `healthChange` - The amount of health to add to the player. Can be a negative value too.
 
 - `HitNoteScriptEvent`, with fields:
-  - Inherited from `NoteScriptEvent`.
-  - `judgement` - The judgement received from hitting the note.
-  - `score` - The score received from hitting the note.
-  - `isComboBreak` - If the hit caused a combo break.
-  - `hitDiff` - The time difference (in miliseconds) when the player hit the note.
-  - `doesNotesplash` - If the note does a splash, defaults to true when the judgement is "sick".
+
+    - Inherited from `NoteScriptEvent`.
+    - `judgement` - The judgement received from hitting the note.
+    - `score` - The score received from hitting the note.
+    - `isComboBreak` - If the hit caused a combo break.
+    - `hitDiff` - The time difference (in miliseconds) when the player hit the note.
+    - `doesNotesplash` - If the note does a splash, defaults to true when the judgement is "sick".
 
 - `HoldNoteScriptEvent`, with fields:
-  - Inherited from `NoteScriptEvent`.
-  - `holdNote` - The SustainTrail object associated with this event.
-  - `score` - The score received from hitting the note.
-  - `isComboBreak` - If the hit caused a combo break.
-  - `hitDiff` - The time difference (in miliseconds) when the player hit the note.
-  - `doesNotesplash` - If the note does a splash, defaults to true when the judgement is "sick".
+
+    - Inherited from `NoteScriptEvent`.
+    - `holdNote` - The SustainTrail object associated with this event.
+    - `score` - The score received from hitting the note.
+    - `isComboBreak` - If the hit caused a combo break.
+    - `hitDiff` - The time difference (in miliseconds) when the player hit the note.
+    - `doesNotesplash` - If the note does a splash, defaults to true when the judgement is "sick".
 
 - `SongTimeScriptEvent`, with fields:
-  - Inherited from `ScriptEvent`.
-  - (read-only) `beat` - The current beat of the song.
-  - (read-only) `step` - The current step of the song.
+
+    - Inherited from `ScriptEvent`.
+    - (read-only) `beat` - The current beat of the song.
+    - (read-only) `step` - The current step of the song.
 
 - `PauseScriptEvent`, with fields:
-  - Inherited from `ScriptEvent`.
-  - `gitaroo` - If the Gitaroo Man easter egg should be used.
+
+    - Inherited from `ScriptEvent`.
+    - `gitaroo` - If the Gitaroo Man easter egg should be used.
 
 - `SongLoadScriptEvent`, with fields:
-  - Inherited from `ScriptEvent`.
-  - (read-only) `id` - The song id associated with the event.
-  - (read-only) `difficulty` - The song difficulty associated with the event.
-  - `notes` - An Array of SongNoteData objects representing the notes for the chart.
-  - `events` - An Array of SongEventData objects representing the events for the chart.
+
+    - Inherited from `ScriptEvent`.
+    - (read-only) `id` - The song id associated with the event.
+    - (read-only) `difficulty` - The song difficulty associated with the event.
+    - `notes` - An Array of SongNoteData objects representing the notes for the chart.
+    - `events` - An Array of SongEventData objects representing the events for the chart.
 
 - `SongRetryEvent`, with fields:
-  - Inherited from `ScriptEvent`.
-  - (read-only) `difficulty` - The new difficulty of the song.
+
+    - Inherited from `ScriptEvent`.
+    - (read-only) `difficulty` - The new difficulty of the song.
 
 - `GhostMissNoteScriptEvent`, with fields:
-  - Inherited from `ScriptEvent`.
-  - (read-only) `dir` - The direction (1-4) that was mistakenly pressed.
-  - (read-only) `hasPossibleNotes` - If there were notes within judgement range when the key was pressed.
-  - `healthChange` - The amount of health to add to the player. Can be a negative value too.
-  - `scoreChange` - The amount of score to add to the player. Can be a negative value too.
-  - `playSound` - Whether to play a miss sound.
-  - `playAnim` - Whether to play a miss animation.
+
+    - Inherited from `ScriptEvent`.
+    - (read-only) `dir` - The direction (1-4) that was mistakenly pressed.
+    - (read-only) `hasPossibleNotes` - If there were notes within judgement range when the key was pressed.
+    - `healthChange` - The amount of health to add to the player. Can be a negative value too.
+    - `scoreChange` - The amount of score to add to the player. Can be a negative value too.
+    - `playSound` - Whether to play a miss sound.
+    - `playAnim` - Whether to play a miss animation.
 
 - `SongEventScriptEvent`, with fields:
-  - Inherited from `ScriptEvent`.
-  - (read-only) `eventData` - The SongEventData object associated with the event.
+
+    - Inherited from `ScriptEvent`.
+    - (read-only) `eventData` - The SongEventData object associated with the event.
 
 - `CountdownScriptEvent`, with fields:
-  - Inherited from `ScriptEvent`.
-  - (read-only) `step` - The current countdown step. Can be *BEFORE*, *THREE*, *TWO*, *ONE*, *GO* or *AFTER*.
+
+    - Inherited from `ScriptEvent`.
+    - (read-only) `step` - The current countdown step. Can be `BEFORE`, `THREE`, `TWO`, `ONE`, `GO` or `AFTER`.
 
 - `DialogueScriptEvent`, with fields:
-  - Inherited from `ScriptEvent`.
-  - (read-only) `conversation` - The Conversation object associated with the event.
+
+    - Inherited from `ScriptEvent`.
+    - (read-only) `conversation` - The Conversation object associated with the event.
 
 ## Script Event Cancelling
 
-While most cannot be cancelled, cancelling some events provides more leeway to the custom behavior. An example to this would be having pre-song cutscenes, as seen in the script file for the song Darnell[^darnell]:
+While most cannot be cancelled, cancelling some events provides more leeway to the custom behavior. An example to this would be having pre-song cutscenes, as seen in the script file for the song Darnell:[^darnell]
 ```haxe
 // ...
 
@@ -207,7 +259,7 @@ public override function onCountdownStart(event:CountdownScriptEvent):Void
 
 ## Overriding Script Event Callbacks
 
-Even if most base classes have the script event callbacks as empty functions, others have behavior that is entirely dependant on them. As such, you can skip the behavior or call it under a condition depending on if and where you put your super function call. One such example is in the script file for Boyfriend (Christmas)[^bf-christmas]:
+Even if most base classes have the script event callbacks as empty functions, others have behavior that is entirely dependant on them. As such, you can skip the behavior or call it under a condition depending on if and where you put your super function call. One such example is in the script file for Boyfriend (Christmas):[^bf-christmas]
 ```haxe
 // ...
 
@@ -234,6 +286,7 @@ function onNoteHit(event:HitNoteScriptEvent)
 
 // ...
 ```
+
 [^darnell]: <https://github.com/FunkinCrew/funkin.assets/blob/main/preload/scripts/songs/darnell.hxc>
 [^bf-christmas]: <https://github.com/FunkinCrew/funkin.assets/blob/main/preload/scripts/characters/bf-christmas.hxc>
 

--- a/assets/content/cookbook/Advanced/8.ScriptEventCallbacks.md
+++ b/assets/content/cookbook/Advanced/8.ScriptEventCallbacks.md
@@ -259,7 +259,7 @@ public override function onCountdownStart(event:CountdownScriptEvent):Void
 
 ## Overriding Script Event Callbacks
 
-Even if most base classes have the script event callbacks as empty functions, others have behavior that is entirely dependant on them. As such, you can skip the behavior or call it under a condition depending on if and where you put your super function call. One such example is in the script file for Boyfriend (Christmas):[^bf-christmas]
+Even if most base classes have the script event callbacks as empty functions, others have behavior that is entirely dependant on them. As such, you can skip the behavior or call it under a condition depending on if and where you put your super function call. One such example is in the script file for Boyfriend (Christmas)[^bf-christmas]
 ```haxe
 // ...
 


### PR DESCRIPTION
# What does this PR fix?
* It fixes formatting issues for the `Script Event Callbacks` article, since it did not properly have footnotes, nested lists as well as in some cases had a space at the end of the sentences.