### PR TITLE
[ENHANCEMENT] Provide more information for Scripted Songs

### DIFF
--- a/assets/content/cookbook/Advanced/3.ScriptedSongs.md
+++ b/assets/content/cookbook/Advanced/3.ScriptedSongs.md
@@ -24,16 +24,37 @@ class BallisticSong extends Song {
 
 You can then add override functions to perform custom behavior.
 
+## Variation-Specific Song Scripts
+
+As of 0.7.4, if in the constructor you were to add an anonymous structure with the field `variation` as a parameter next to the song id, the song script will only be active for that variation. This prevents many conflicts with base game scripts and other mods that may add a variation, as the game would only call the functions from the variation-specific script. If a song doesn't have a variation-specific script, it will fallback to the default one, if it exists. An example of a variation-specific script can be found for Darnell Erect[^darnell]
+```haxe
+import funkin.play.song.Song;
+import funkin.save.Save;
+
+class DarnellErectSong extends Song
+{
+    public function new()
+    {
+        super('darnell',
+        {
+            variation: 'erect'
+        });
+    }
+
+    // ...
+}
+```
+
 ## Custom 'NEW'-Label criteria
 
-Usually, in the Freeplay menu, a song would not have the glowing 'NEW' label. However if you override the function `isSongNew`, you can have the label appear if a specific criteria is met. An example of this is found in the script for Cocoa[^cocoa] which returns true if the variation is Pico and the player hasn't beaten Cocoa Pico Mix.
+Usually, in the Freeplay menu, a song would not have the glowing 'NEW' label. However if you override the function `isSongNew`, you can have the label appear if a specific criteria is met. An example of this is found in the script for Cocoa (Pico Mix)[^cocoa] which returns true if the variation is Pico and the player hasn't beaten Cocoa Pico Mix.
 ```haxe
 // ...
 
-// Line 29
+// Line 14
 public override function isSongNew(currentDifficulty:String, currentVariation:String):Bool
 {
-    if (currentVariation == 'pico') return !Save.instance.hasBeatenSong(this.id, null, 'pico');
+    if (currentVariation == 'pico') return !Save.instance.hasBeatenSong(this.id, null, this.variation);
 
     return false;
 }
@@ -47,25 +68,19 @@ Instead of reading from the song's metadata file for possible alternate instrume
 ```haxe
 // ...
 
-// Line 42
+// Line 21
 public override function listAltInstrumentalIds(difficultyId:String, variationId:String):Array<String>
 {
+    var results:Array<String> = super.listAltInstrumentalIds(difficultyId, variationId);
+
     if (difficultyId == 'easy' || difficultyId == 'normal' || difficultyId == 'hard')
     {
         var hasBeatenPicoMix = Save.instance.hasBeatenSong(this.id, null, 'pico');
 
-        switch (variationId)
-        {
-            case 'pico':
-                // return hasBeatenPicoMix ? [''] : [];
-                // No Pico mix on BF instrumental, sorry!
-                return [];
-            default:
-                return hasBeatenPicoMix ? ['pico'] : [];
-        }
+        if (!hasBeatenPicoMix) results = [for (id in results) if (id != 'pico') id];
     }
 
-    return [];
+    return results;
 }
 
 // ...
@@ -92,8 +107,9 @@ public function listDifficulties(variationId:String, variationIds:Array<String>,
 // ...
 ```
 
-[^cocoa]: <https://github.com/FunkinCrew/funkin.assets/blob/main/preload/scripts/songs/cocoa.hxc>
-[^2hot]: <https://github.com/FunkinCrew/funkin.assets/blob/main/preload/scripts/songs/2hot.hxc>
+[^darnell]: <https://github.com/FunkinCrew/funkin.assets/blob/main/preload/scripts/songs/darnell-erect.hxc>
+[^cocoa]: <https://github.com/FunkinCrew/funkin.assets/blob/main/preload/scripts/songs/cocoa-pico.hxc>
 [^stress]: <https://github.com/FunkinCrew/funkin.assets/blob/main/preload/scripts/songs/stress.hxc>
+[^2hot]: <https://github.com/FunkinCrew/funkin.assets/blob/main/preload/scripts/songs/2hot.hxc>
 
 > Author: [EliteMasterEric](https://github.com/EliteMasterEric)


### PR DESCRIPTION
This PR adds documentation on `listAltInstrumentalIds`, `listDifficulties` and `isSongNew`, which I found to be the most useful functions for scripted songs aside from script event callbacks.

This PR alsso adds variation specific song scripts, as they have been added in 0.7.4.