### PR TITLE
[ENHANCEMENT] Change `SparrowCharacter` to `PlayableCharacter` for scripted playable characters

### DIFF
--- a/assets/content/cookbook/Advanced/5.ScriptedPlayableCharacters.md
+++ b/assets/content/cookbook/Advanced/5.ScriptedPlayableCharacters.md
@@ -3,19 +3,18 @@
 
 This chapter will walk you through the process of adding a script to a Playable Character, and giving examples of the kind of custom behavior which can be implemented with this functionality.
 
-Start by creating a scripted class file with the `.hxc` extension (in the `mods/mymod/scripts/characters` if you want to keep things organized).
+Start by creating a scripted class file with the `.hxc` extension (in the `mods/mymod/scripts/players` if you want to keep things organized).
 
 ```haxe
 // Remember to import each class you want to reference in your script!
-import funkin.play.character.SparrowCharacter;
+import funkin.ui.freeplay.charselect.PlayableCharacter;
 
-// Choose a name for your scripted class that will be unique, and make sure to specifically extend the correct character class.
-// SparrowCharacter is the one to use for XML-based characters.
+// Choose a name for your scripted class that will be unique, and make sure to specifically extend the PlayableCharacter class.
 // This class's functions will override the default behavior for the character.
-class WhittyCharacter extends SparrowCharacter {
+class WhittyPlayer extends PlayableCharacter {
 	public function new() {
         // The constructor gets called whenever the character is spawned.
-        // The constructor takes one parameter, which is the song ID for the song you are applying the script to.
+        // The constructor takes one parameter, which is the player ID for the player you are applying the script to.
 		super('whitty');
 	}
 


### PR DESCRIPTION
Changes the class of the example to be `PlayableCharacter` to not confuse readers when reading the Scripted Playable Characters article. Also changes some comments to accomodate this change.