### PR TITLE
[FIX] Fix Broken Hyperlinks after filename prepended `0`

### DIFF
--- a/assets/content/cookbook/Advanced/02.ScriptedClasses.md
+++ b/assets/content/cookbook/Advanced/02.ScriptedClasses.md
@@ -24,9 +24,9 @@ class BallisticSong extends Song {
 
 There is a predefined list of classes which the game has set up to be scriptable, and will automatically load and execute when relevant. More of these will be added in the future.
 
-- `funkin.play.song.Song` for providing unique behavior to custom songs, including playing cutscenes and other stuff. See [Scripted Songs](3.ScriptedSongs.md).
-	- See also [Video Cutscenes](6.VideoCutscenes.md), [Ingame Cutscenes](21-scripted-classes/21-04-ingame-cutscenes.md), and [Dialogue Cutscenes](7.DialogueCutscenes.md)
-- `funkin.play.character.BaseCharacter` for providing unique behavior to custom characters (such as playing custom animations in certain circumstances). See [Scripted Characters](4.ScriptedCharacters.md).
+- `funkin.play.song.Song` for providing unique behavior to custom songs, including playing cutscenes and other stuff. See [Scripted Songs](03.ScriptedSongs.md).
+	- See also [Video Cutscenes](09.VideoCutscenes.md), [Ingame Cutscenes](21-scripted-classes/21-04-ingame-cutscenes.md), and [Dialogue Cutscenes](08.DialogueCutscenes.md)
+- `funkin.play.character.BaseCharacter` for providing unique behavior to custom characters (such as playing custom animations in certain circumstances). See [Scripted Characters](04.ScriptedCharacters.md).
 
 	- Note that you need to choose the correct subclass of this class for the animation type of your character!
 
@@ -42,12 +42,12 @@ There is a predefined list of classes which the game has set up to be scriptable
 - `funkin.ui.freeplay.charselect.PlayableCharacter` for providing unique behavior to custom playable characters. See [Scripted Playable Characters](5.ScriptedPlayableCharacters.md)
 - `funkin.ui.freeplay.FreeplayStyle` for defining the sprites and colors used by the Freeplay menu when a given character is selected. See [WIP]
 - `funkin.play.notes.notestyle.NoteStyle` for modifying the behavior of custom note styles. See [WIP]
-- `funkin.play.cutscene.dialogue.Conversation` for providing unique behavior to custom dialogue conversations. See [Dialogue Cutscenes](7.DialogueCutscenes.md)
-- `funkin.play.cutscene.dialogue.DialogueBox` for providing unique behavior to custom dialogue boxes used in conversations. See [Dialogue Cutscenes](7.DialogueCutscenes.md)
-- `funkin.play.cutscene.dialogue.Speaker` for providing unique behavior to custom speakers used in conversations. See [Dialogue Cutscenes](7.DialogueCutscenes.md)
+- `funkin.play.cutscene.dialogue.Conversation` for providing unique behavior to custom dialogue conversations. See [Dialogue Cutscenes](08.DialogueCutscenes.md)
+- `funkin.play.cutscene.dialogue.DialogueBox` for providing unique behavior to custom dialogue boxes used in conversations. See [Dialogue Cutscenes](08.DialogueCutscenes.md)
+- `funkin.play.cutscene.dialogue.Speaker` for providing unique behavior to custom speakers used in conversations. See [Dialogue Cutscenes](08.DialogueCutscenes.md)
 - `funkin.ui.freeplay.Album` for defining custom behavior for Freeplay Albums. See [WIP]
 
-There is also `funkin.modding.module.Module` for custom scripted Modules, which are scripts which receive events everywhere, rather than only in a specific context. See [Scripted Modules](30-scripted-modules/30-00-scripted-modules.md) for more information on how these work.
+There is also `funkin.modding.module.Module` for custom scripted Modules, which are scripts which receive events everywhere, rather than only in a specific context. See [Scripted Modules](../Expert/01.ScriptedModules.md) for more information on how these work.
 
 There are also scripted classes are also set up to be scriptable, but will only be useful if they're accessed from another script. Expect more of these to be added in the future.
 

--- a/assets/content/cookbook/Expert/01.ScriptedModules.md
+++ b/assets/content/cookbook/Expert/01.ScriptedModules.md
@@ -50,6 +50,6 @@ Modules have all the events most scripts have, but the difference is. You also h
 
 Modules also have a priority system for compatibility with other mods, in your construction method, `new()`, you can set the `priority` property (which defaults to `1000`). 1 is processed before anything else.
 
-You can view a detailed list of script events and their callbacks in [here](../Advanced/6.ScriptEventCallbacks.md)
+You can view a detailed list of script events and their callbacks in [here](../Advanced/06.ScriptEventCallbacks.md)
 
 > Author: [Kade](https://github.com/Kade-github)

--- a/assets/content/cookbook/Intermediate/01.CustomPlayableCharacters.md
+++ b/assets/content/cookbook/Intermediate/01.CustomPlayableCharacters.md
@@ -10,10 +10,10 @@ This chapter goes over adding new playable characters to the game, ensuring that
 
 In order to make a fleshed out custom character that can be used from Character Select in Friday Night Funkin', you need a large number of textures, animations, and audio tracks:
 
-- A [custom character](../Introduction/3.CustomCharacters.md).
+- A [custom character](../Introduction/03.CustomCharacters.md).
 
     - This requires a set of singing animations for the character.
-- At least one custom song that uses that character; this can be either [a new song](../Introduction/2.CustomSongs.md#adding-the-custom-song) or a [variation added to an existing song](../Introduction/2.CustomSongs.md#adding-variations-to-existing-songs).
+- At least one custom song that uses that character; this can be either [a new song](../Introduction/02.CustomSongs.md#adding-the-custom-song) or a [variation added to an existing song](../Introduction/02.CustomSongs.md#adding-variations-to-existing-songs).
 
     - This requires an instrumental and split vocal tracks.
 - A pixel icon asset to use for that character's icon in the Character Select grid.
@@ -208,13 +208,13 @@ The available fields are:
 
 - `version`: The version number for the Playable Character data file format. Leave this at `1.0.0`.
 - `name`: The readable name for the character, used internally.
-- `ownedCharacters`: The list of [Characters](../Introduction/3.CustomCharacters.md) this character owns.
+- `ownedCharacters`: The list of [Characters](../Introduction/03.CustomCharacters.md) this character owns.
 
     - When determining which songs to display in Freeplay, the game checks for any songs where the player character is in this list and displays those. Songs where the player character is in another array are not displayed.
 - `showUnownedChars`: If this value is `true`, then songs whose player character is not in any `ownedCharacters` list will be displayed for this character.
 - `unlocked`: Whether the character is unlocked.
 
-    - Create a scripted class for this playable character and override `isUnlocked():Bool` to make this conditional. See [Scripted Playable Characters](../Advanced/5.ScriptedPlayableCharacters.md)
+    - Create a scripted class for this playable character and override `isUnlocked():Bool` to make this conditional. See [Scripted Playable Characters](../Advanced/05.ScriptedPlayableCharacters.md)
 - `freeplayStyle`: The ID for a Freeplay style to display.
 
     - You can use `"bf"` here to use Boyfriend's Freeplay style as a default, or create a new JSON file in the `data/ui/freeplay/styles` folder (copy the Pico one and edit that).

--- a/assets/content/cookbook/Intermediate/03.CustomStickerPacks.md
+++ b/assets/content/cookbook/Intermediate/03.CustomStickerPacks.md
@@ -58,7 +58,7 @@ For example, to add to Boyfriend's standard sticker pack, you can use the follow
 
 There are two ways the game defines a given sticker pack to be used:
 
-- Each [Playable Character](1.CustomPlayableCharacters.md) defines the `stickerPack` variable, which specifies the sticker pack to be used by songs containing that character. For example, `bf` uses the `standard-bf` sticker pack. You can define a sticker pack to be used for your custom playable character by setting the `stickerPack` value, or modify which sticker pack is used by other playable characters by using [JSONPatch](../Introduction/5.AppendingAndMerge.md#merging) to modify the `stickerPack` value of that character.
+- Each [Playable Character](01.CustomPlayableCharacters.md) defines the `stickerPack` variable, which specifies the sticker pack to be used by songs containing that character. For example, `bf` uses the `standard-bf` sticker pack. You can define a sticker pack to be used for your custom playable character by setting the `stickerPack` value, or modify which sticker pack is used by other playable characters by using [JSONPatch](../Introduction/05.AppendingAndMerge.md#merging) to modify the `stickerPack` value of that character.
 - Each song has a value in its metadata to define which sticker pack is used. Set the `playData.stickerPack` on a song (or use JSONPatch to modify metadata of an existing song) to override which sticker pack it uses.
 
 The game checks and uses sticker packs in this order:

--- a/assets/content/cookbook/Intermediate/04.CustomAlbums.md
+++ b/assets/content/cookbook/Intermediate/04.CustomAlbums.md
@@ -61,7 +61,7 @@ Animation data is structured like so:
 
 # Using the Album
 
-Albums are defined on a per-song basis, so you have to set the album ID for each song. In order to do this, you first have to make the song the itself. See [Custom Songs and Custom Levels](../Introduction/2.CustomSongs.md).
+Albums are defined on a per-song basis, so you have to set the album ID for each song. In order to do this, you first have to make the song the itself. See [Custom Songs and Custom Levels](../Introduction/02.CustomSongs.md).
 
 When you are done creating the song, head over to the `metadata.json` of the song where you want to album to appear and check in `playData` for the `album` key.
 

--- a/assets/content/cookbook/Intermediate/05.Migration.md
+++ b/assets/content/cookbook/Intermediate/05.Migration.md
@@ -138,6 +138,6 @@ if (Std.isOfType(currentState, OptionsState)) {
 
 v0.6.0 rewrote how stickers get used by the game (and v0.6.3 rewrote it again but better this time). Any existing mods that provided stickers will probably break.
 
-New or updating mods looking to add, remove, or replace stickers should consult the [custom Sticker Packs documentation](3.CustomStickerPacks.md)
+New or updating mods looking to add, remove, or replace stickers should consult the [custom Sticker Packs documentation](03.CustomStickerPacks.md)
 
 > Author: [EliteMasterEric](https://github.com/EliteMasterEric)

--- a/assets/content/cookbook/Introduction/03.CustomCharacters.md
+++ b/assets/content/cookbook/Introduction/03.CustomCharacters.md
@@ -240,6 +240,6 @@ The UI will show you all of the possible controls and shortcuts, to make your pr
 Once you are happy with your result, simply press `ESC` on your keyboard to save the `Character Data` file.
   - Currently there is a bug which makes the file saving system not automatically put character's ID in the file name, which you will have to do yourself. Simply name the file the ID of your character followed by `.json`.
 
-From the beginning of this chapter you will know, that you have to place this character data JSON file in `data/characters`. Then, you can simply use [Hot Reloading](../Introduction/1.Introduction.md#hot-reloading) to check the offsets without restarting the game.
+From the beginning of this chapter you will know, that you have to place this character data JSON file in `data/characters`. Then, you can simply use [Hot Reloading](../Introduction/01.Introduction.md#hot-reloading) to check the offsets without restarting the game.
 
 > Author: [EliteMasterEric](https://github.com/EliteMasterEric)


### PR DESCRIPTION
# What does this PR fix?
* This PR fixes all of the links being broken since https://github.com/FunkinCrew/code-cookbook/commit/0c26715a9359a7ab49f495c4ca18e48183341e6c prepended `0` in every single files name.
* This PR now links users to the scripted modules article added in https://github.com/FunkinCrew/code-cookbook/commit/bf690c138819fe2a54e1c27d81fc314f55c82e4f.