### PR TITLE
[FORMATTING] Update `03.CustomCharacters` formatting

### DIFF
--- a/assets/content/cookbook/Introduction/03.CustomCharacters.md
+++ b/assets/content/cookbook/Introduction/03.CustomCharacters.md
@@ -231,14 +231,16 @@ Once you have accessed the tool, it might be a little overwhelming at first, but
 
 The first thing you have to do is click `2` on your keyboard to switch to `Animation Mode` in order to properly fix offsets for each animation. Then, you need to select your character from the `Character` section in the UI box that is located in the top-left corner.
 
-*HINT:* The best thing to do to speed up your process, it to toggle `Onion Skin` mode by pressing `F`. This will show the previous animation played being half transparent. This can help speeding up the proccess, since you will be able to to properly line up the animation with the previous one.
+> [!TIP]
+> The best thing to do to speed up your process, it to toggle `Onion Skin` mode by pressing `F`. This will show the previous animation played being half transparent. This can help speeding up the proccess, since you will be able to to properly line up the animation with the previous one.
 
 The UI will show you all of the possible controls and shortcuts, to make your proccess of fixing the character offsets much easier.
 
 ## Saving Offsets
 
 Once you are happy with your result, simply press `ESC` on your keyboard to save the `Character Data` file.
-  - Currently there is a bug which makes the file saving system not automatically put character's ID in the file name, which you will have to do yourself. Simply name the file the ID of your character followed by `.json`.
+> [!NOTE]
+> In case you want to save the offsets of your character, you are able to do so by pressing `CTRL+ESC` on your keyboard to save the offsets.
 
 From the beginning of this chapter you will know, that you have to place this character data JSON file in `data/characters`. Then, you can simply use [Hot Reloading](../Introduction/1.Introduction.md#hot-reloading) to check the offsets without restarting the game.
 


### PR DESCRIPTION
# What does this PR fix?
This PR does a few following things:
* Updates a bit of the formatting to include added `Github Alert Markdowns`.
* Removes a comment saying there is a bug when saving the characters data file.
* Adds a comment saying that it is possible to save ONLY the character offsets.