### PR TITLE
add vscode file association for .mtt files -> .html

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -1,0 +1,4 @@
+{"files.associations": {
+        "*.mtt": "html"
+    }
+}


### PR DESCRIPTION
Just a small little thing, makes VSCode syntax highlight the `.mtt` files as if they are `.html` files, which makes them a bit more readable