### PR TITLE
Add `albumOSTName` to the Custom Albums guide

### DIFF
--- a/assets/content/cookbook/Intermediate/04.CustomAlbums.md
+++ b/assets/content/cookbook/Intermediate/04.CustomAlbums.md
@@ -40,6 +40,7 @@ While there is not a lot, some stuff still need to be shown so you know what is 
   - Use an array of two decimal values, the first for horizontal position and the second for vertical position.
 
 - `albumTitleAnimations`: A list of animation data objects for the album title. Optional, defaults to `[]`, aka nothing.
+- `albumOSTName`: A name that changes the text for the OST in Freeplay. Optional, defaults to `null`, aka nothing.
 
 Animation data is structured like so:
 


### PR DESCRIPTION
> [!NOTE]
> Better merged only after 0.8.4 (or whatever version the next update will be), which is when it will actually be available to use.

Adds documentation for the newly introduced album data entry.