### PR TITLE
[CHORE] Fix typo in Using Saves article + Formatter

### DIFF
--- a/assets/content/cookbook/Expert/04.UsingSaves.md
+++ b/assets/content/cookbook/Expert/04.UsingSaves.md
@@ -11,16 +11,17 @@ This chapter will walk you through using the game's global save file to store yo
 To access the currently used save file, you must first import the `funkin.save.Save` class in your script. Afterwards, you can do something like this to access the save file:
 
 ```haxe
-import funkin.save.Save;  
+import funkin.save.Save;
 
-// ...  
+// ...
 
-public override function onCreate(event:ScriptEvent)  
-{  
-    // Access the characters that are selectable in the Character Select menu.  
-    var charactersSeen:Array<String> = Save.instance.charactersSeen.value;  
+    var charactersSeen:Array<String> = Save.instance.charactersSeen.value;
+public override function onCreate(event:ScriptEvent)
+{
+    // Access the characters that are selectable in the Character Select menu.
+    var charactersSeen:Array<String> = Save.instance.charactersSeen.value;
 
-    // ... some functionality  
+    // ... some functionality
 }
 ```
 
@@ -52,12 +53,12 @@ You can store a value to the modOptions by doing something like the following ex
 import funkin.play.PlayState;
 import funkin.save.Save;
 
-// ... 
+// ...
 
 public override function onSongEnd(event:ScriptEvent)
 {
     // Store the completion of a song if the player's score is higher than 100,000.
-    if (PlayState.instance.songScore > 100000) 
+    if (PlayState.instance.songScore > 100000)
     {
         Save.instance.modOptions.set("hasMoreThan100k", true);
         Save.instance.flush();
@@ -71,17 +72,17 @@ public override function onSongEnd(event:ScriptEvent)
 To access the stored value, you can to something like this. It is important to account for the player not having any stored value in their save file and, if so, returning a fallback.
 
 ```haxe
-public override function onCreate(event:ScriptEvent)  
-{  
-    // Check if the player had met the previously established criteria.  
-    var hasMetCriteria:Bool = false.  
-    if (Save.instance.modOptions.exists("hasMoreThan100k"))  
-    {  
-        hasMetCriteria = Save.instance.modOptions.get("hasMoreThan100k");  
-    }  
+public override function onCreate(event:ScriptEvent)
+{
+    // Check if the player had met the previously established criteria.
+    var hasMetCriteria:Bool = false;
+    if (Save.instance.modOptions.exists("hasMoreThan100k"))
+    {
+        hasMetCriteria = Save.instance.modOptions.get("hasMoreThan100k");
+    }
 
-    // ... some check or functionality here  
-} 
+    // ... some check or functionality here
+}
 ```
 
 > Author: [KoloInDaCrib](https://github.com/KoloInDaCrib)


### PR DESCRIPTION
## What does this PR do?

* Added missing semicolons
* Removes trailining whitespaces (Prettier Code Formatter)