### PR TITLE
Remove `"value": null` from song variation merging

### DIFF
--- a/assets/content/cookbook/Introduction/05.AppendingAndMerge.md
+++ b/assets/content/cookbook/Introduction/05.AppendingAndMerge.md
@@ -228,9 +228,7 @@ Enter the `inverse` property, and the `test` operation:
   [
     // If `songVariations` does not have a given value, then the next patch gets triggered.
     // Our operation below works the same as `test`, but in reverse, hence the name `inverse`.
-    // 
-    // Basically, if `songVariations` is not `value`, then the next patches will be rejected.
-    {"op": "test", "path": "/playData/songVariations", "value": null, "inverse": true},
+    {"op": "test", "path": "/playData/songVariations", "inverse": true},
 
     // Set `songVariations` to [].
     {"op": "add", "path": "/playData/songVariations", "value": []}


### PR DESCRIPTION
Running a patch that checks if a value is null checks if it's literally null, instead of whether it exists or not, causing some songs to break and lose all their variations.